### PR TITLE
fixes the commands in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Open the Command Palette (Command+Shift+P on macOS and Ctrl+Shift+P on Windows/L
 
 Command | Description
 --- | ---
-```Git Graphy: View Commits``` | View Commit Chart by author.
-```Git Graphy: View Commits Per File``` | View Commit Chart per file.
-```Git Graphy: View Largest files``` | Show the largest files in the repository.
+```GitGraphy: View Commits``` | View Commit Chart by author.
+```GitGraphy: View Commits Per File``` | View Commit Chart per file.
+```GitGraphy: View Largest files``` | Show the largest files in the repository.
 ```GitGraphy: View the files with the most contributors``` | Show the files with the most contributors in the repository.
 
 ## Output samples


### PR DESCRIPTION
I had some trouble running the commands found in the readme, until i noticed that they don't have a space. Here's a PR to address that. 

![image](https://user-images.githubusercontent.com/834948/102656865-9ba71f00-4142-11eb-9c0a-7d49318b3465.png)
